### PR TITLE
add \usepackage[T1]{fontenc} to fix åäö

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -11,6 +11,7 @@
 \usepackage{hyperref}
 \usepackage{xcolor}
 \usepackage{graphicx}
+\usepackage[T1]{fontenc}
 
 % lägg till egna macros
 \input{macros}


### PR DESCRIPTION

copying text that includes å, ä and ö without this package makes the text look weird